### PR TITLE
Don't mutate SimpleMarkdown rules

### DIFF
--- a/Markdown.js
+++ b/Markdown.js
@@ -37,15 +37,16 @@ var styles = {
 var Markdown = React.createClass({
 
   componentWillMount: function() {
-    var rules = require('./rules')(_.merge(styles, this.props.style));
-    rules = _.merge(SimpleMarkdown.defaultRules, rules);
+    var mergedStyles = _.merge({}, styles, this.props.style);
+    var rules = require('./rules')(mergedStyles);
+    rules = _.merge({}, SimpleMarkdown.defaultRules, rules);
 
     var parser = SimpleMarkdown.parserFor(rules);
     this.parse = function(source) {
       var blockSource = source + '\n\n';
       return parser(blockSource, {inline: false});
     };
-    this.renderer = SimpleMarkdown.outputFor(SimpleMarkdown.ruleOutput(rules, 'react'));
+    this.renderer = SimpleMarkdown.reactFor(SimpleMarkdown.ruleOutput(rules, 'react'));
   },
 
   render: function() {


### PR DESCRIPTION
Summary:
_.merge mutates the first parameter, and we probably should not
mutate SimpleMarkdown.defaultRules (in practice this probably
doesn't matter, but in theory an app could have two dependencies
which use SimpleMarkdown, or want to render markdown to a webview,
or something else edge-case-y).

This commit also changes SimpleMarkdown.outputFor to
SimpleMarkdown.reactFor (the former is deprecated).

Test Plan:
I don't have react-native installed right now, so hopefully I didn't
break anything! You should probably test this before merging <3
